### PR TITLE
:rocket: feat: 아이피 변경에 대해 반영

### DIFF
--- a/comcigan/async_school.py
+++ b/comcigan/async_school.py
@@ -30,7 +30,7 @@ def trim(lis):
     return lis
 
 
-URL = "http://112.186.146.81:4082"
+URL = "http://112.186.226.178:4082"
 
 
 class CONSTANT:

--- a/comcigan/school.py
+++ b/comcigan/school.py
@@ -24,7 +24,7 @@ def trim(lis):
     return lis
 
 
-URL = "http://112.186.146.81:4082"
+URL = "http://112.186.226.178:4082"
 
 comci_resp = get(f"{URL}/st")
 comci_resp.encoding = "EUC-KR"


### PR DESCRIPTION
구조 변경과 함께 아이피가 변경된거로 보여 해당 부분 패치하여 PR 드립니다. 확인하고 머지 해주시면 감사드리겠습니다.
112.186.146.81 -> 112.186.226.178, comci.kr -> comci.net

146.81과 거기에 매치되는 comci.kr은 현재 L4 로드밸런서 스위칭 분기가 되는데, 일부 로드밸런서는 아직 신규도메인/아이피로 포워딩 해주고 있지 않아 간헐적으로 오류가 나는 것으로 보여

확실하게 신규 아이피로 밀고 나가는 쪽으로 PR 드리고자 합니다.